### PR TITLE
Display line of possible match

### DIFF
--- a/lib/Zarn/AST.pm
+++ b/lib/Zarn/AST.pm
@@ -66,8 +66,9 @@ package Zarn::AST {
         );
 
         if ($var_token && $var_token -> can("parent")) {
-            if (($var_token -> parent -> isa("PPI::Token::Operator") || $var_token -> parent -> isa("PPI::Statement::Expression"))) {                                    
-                print "[$category] - FILE:$file \t Potential: $title.\n";
+            if (($var_token -> parent -> isa("PPI::Token::Operator") || $var_token -> parent -> isa("PPI::Statement::Expression"))) {
+                my ($line, $rowchar) = @{ $var_token -> location };
+                print "[$category] - FILE:$file \t Potential: $title. \t Line: $line:$rowchar.\n";
             }
         }
     }


### PR DESCRIPTION
Great project guys, there's a lack of tools like this for Perl ecosystem! :smile:

I would like to contribute with a very minor feature that I believe it is quite handy, especially when you run `zarn` on a lengthy file. Basically by adding the line of the match it will be quicker to jump to the right place in the source code.