### PR TITLE
Remove duplicate "rules" key in prototype.yml

### DIFF
--- a/rules/prototype.yml
+++ b/rules/prototype.yml
@@ -6,7 +6,6 @@ rules:
     message: Occur when untrusted data is rendered as HTML without proper escaping, allowing attackers to execute malicious scripts in the context of the victim's browser.
     sample:
       - render
-  rules:
   - id: '0012'
     category: vuln
     name: Command Injection


### PR DESCRIPTION
There is an additional "rules" key making prototype.yml an invalid YAML