### PR TITLE
Detection of Perl backticks (`command`) as a potential Remote Code Execution (RCE)

### DIFF
--- a/lib/Zarn/Engine/Source_to_Sink.pm
+++ b/lib/Zarn/Engine/Source_to_Sink.pm
@@ -7,7 +7,7 @@ package Zarn::Engine::Source_to_Sink {
     use PPI::Document;
     use Zarn::Engine::Taint_Analysis;
 
-    our $VERSION = '0.0.4';
+    our $VERSION = '0.0.5';
 
     sub new {
         my ($self, $parameters) = @_;
@@ -58,14 +58,28 @@ package Zarn::Engine::Source_to_Sink {
                     next;
                 }
 
-                my $next_element = $token -> snext_sibling;
-                if (!defined $next_element || !ref $next_element) {
-                    next;
+                my $variable_name;
+
+                if (ref($token) eq 'PPI::Token::QuoteLike::Backtick') {
+                    $variable_name = $token -> content() =~ /[\$\@\%](\w+)/xms ? $1 : undef;
+
+                    if (!$variable_name) {
+                        next;
+                    }
                 }
 
-                my $variable_name = $next_element -> content() =~ /[\$\@\%](\w+)/xms ? $1 : undef;
                 if (!$variable_name) {
-                    next;
+                    my $next_element = $token -> snext_sibling;
+
+                    if (!defined $next_element || !ref $next_element) {
+                        next;
+                    }
+
+                    $variable_name = $next_element -> content() =~ /[\$\@\%](\w+)/xms ? $1 : undef;
+
+                    if (!$variable_name) {
+                        next;
+                    }
                 }
 
                 my $taint_analysis = Zarn::Engine::Taint_Analysis -> new ([

--- a/lib/Zarn/Engine/Taint_Analysis.pm
+++ b/lib/Zarn/Engine/Taint_Analysis.pm
@@ -6,7 +6,7 @@ package Zarn::Engine::Taint_Analysis {
     use PPI::Document;
     use List::Util 'any';
 
-    our $VERSION = '0.0.2';
+    our $VERSION = '0.0.3';
 
     sub new {
         my ($self, $parameters) = @_;
@@ -30,8 +30,8 @@ package Zarn::Engine::Taint_Analysis {
                 my @childrens = $var_token -> parent() -> children();
 
                 # verifyng if the variable is a fixed string or a number
+                # Note: double-quoted strings can contain interpolated variables, so they are not safe
                 if (any {
-                    $_ -> isa('PPI::Token::Quote::Double') ||
                     $_ -> isa('PPI::Token::Quote::Single') ||
                     $_ -> isa('PPI::Token::Number')
                 } @childrens) {

--- a/rules/default.yml
+++ b/rules/default.yml
@@ -18,6 +18,7 @@ rules:
       - exec
       - qx
       - do
+      - '`'
   - id: '0003'
     type: presence
     category: vuln


### PR DESCRIPTION
This PR adds detection of Perl backticks (`command`) as a potential Remote Code Execution (RCE) risk. Backticks can execute system commands, and were not previously covered by the existing dangerous function checks.

I also fixed a bug: double-quoted strings can contain interpolated variables, so they are not safe.