### PR TITLE
Replace ternary regex captures with explicit match blocks in Source_to_Sink

### DIFF
--- a/lib/Zarn/Network/Source_to_Sink.pm
+++ b/lib/Zarn/Network/Source_to_Sink.pm
@@ -63,7 +63,12 @@ package Zarn::Network::Source_to_Sink {
                 my $variable_name;
 
                 if (ref($token) eq 'PPI::Token::QuoteLike::Backtick') {
-                    $variable_name = $token -> content() =~ /[\$\@\%](\w+)/xms ? $1 : undef;
+                    my $token_content = $token -> content();
+                    $variable_name = undef;
+
+                    if ($token_content =~ /[\$\@\%](\w+)/xms) {
+                        $variable_name = $1;
+                    }
 
                     if (!$variable_name) {
                         next;
@@ -77,7 +82,12 @@ package Zarn::Network::Source_to_Sink {
                         next;
                     }
 
-                    $variable_name = $next_element -> content() =~ /[\$\@\%](\w+)/xms ? $1 : undef;
+                    my $next_content = $next_element -> content();
+                    $variable_name = undef;
+
+                    if ($next_content =~ /[\$\@\%](\w+)/xms) {
+                        $variable_name = $1;
+                    }
 
                     if (!$variable_name) {
                         next;


### PR DESCRIPTION
### Motivation
- Improve clarity by replacing inline ternary regex assignments with explicit match blocks and temporary variables.
- Conform to the project style that avoids ternary operators and to the requirement to remove `else` branches.
- Make variable-extraction control flow explicit for `PPI::Token::QuoteLike::Backtick` handling and the `snext_sibling` fallback.

### Description
- Replaced ternary assignments such as ``$variable_name = $token -> content() =~ /.../ ? $1 : undef`` with an explicit `my $token_content` and `if ($token_content =~ /.../) { $variable_name = $1 }` block in `lib/Zarn/Network/Source_to_Sink.pm`.
- Added an explicit `my $next_content` extraction and set ``$variable_name = undef`` before performing the regex match for the `snext_sibling` fallback path.
- Removed `else` branches and preserved the existing early `next` control flow behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965878ccfcc832b84933a366c98644f)