### PR TITLE
Move Mojolicious rules into dedicated ruleset

### DIFF
--- a/rules/mojolicious.yml
+++ b/rules/mojolicious.yml
@@ -1,0 +1,29 @@
+---
+rules:
+  - id: '0007'
+    type: presence
+    category: vuln
+    name: Mojolicious XSS
+    message: Occur when untrusted data is rendered in Mojolicious templates or responses without proper escaping, allowing malicious scripts to run in the browser.
+    sample:
+      - render
+      - render_to_string
+      - render_later
+  - id: '0008'
+    type: presence
+    category: vuln
+    name: Mojolicious SSTI
+    message: Occur when user input is interpolated into Mojolicious templates or inline rendering, enabling server side template injection.
+    sample:
+      - inline
+      - template
+      - renderer
+  - id: '0009'
+    type: presence
+    category: vuln
+    name: Mojolicious WebSocket Cross Hijacking
+    message: Occur when WebSocket connections lack origin or session validation, allowing cross-site WebSocket hijacking.
+    sample:
+      - websocket
+      - on
+      - send


### PR DESCRIPTION
### Motivation
- Consolidate Mojolicious-specific security checks to keep the baseline `rules/default.yml` focused on general rules.
- Provide clearer organization for framework-specific detections for XSS, SSTI, and WebSocket cross-hijacking.

### Description
- Added a new file `rules/mojolicious.yml` containing presence rules `0007` (Mojolicious XSS), `0008` (Mojolicious SSTI), and `0009` (Mojolicious WebSocket Cross Hijacking).
- Removed the Mojolicious rules from `rules/default.yml` so framework checks are no longer mixed with baseline rules.
- Each rule includes a `message` and `sample` tokens such as `render`, `inline`, and `websocket` to guide detection.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966d5871008832bbc73e83239aaf492)