### PR TITLE
Ensure Perl test modules end with a true value (`1;`)

### DIFF
--- a/tests/AliasAnalyzer.t
+++ b/tests/AliasAnalyzer.t
@@ -63,3 +63,4 @@ my @value_aliases = $extra_def_use -> {get_aliases} -> ('value');
 is(scalar @value_aliases, 0, 'No aliases recorded for non-symbol casts');
 
 done_testing();
+1;

--- a/tests/CallGraphBuilder.t
+++ b/tests/CallGraphBuilder.t
@@ -20,3 +20,4 @@ my $no_file_builder = Zarn::Component::Engine::CallGraphBuilder -> new([]);
 is($no_file_builder, 0, 'Missing file returns 0');
 
 done_testing();
+1;

--- a/tests/DataFlow.t
+++ b/tests/DataFlow.t
@@ -39,3 +39,4 @@ my $missing_network = Zarn::Network::DataFlow -> new([]);
 is($missing_network, 0, 'Missing parameters returns 0');
 
 done_testing();
+1;

--- a/tests/DefUseAnalyzer.t
+++ b/tests/DefUseAnalyzer.t
@@ -89,3 +89,4 @@ my $missing_analyzer = Zarn::Component::Engine::DefUseAnalyzer -> new([]);
 is($missing_analyzer, 0, 'Missing AST returns 0');
 
 done_testing();
+1;

--- a/tests/Files.t
+++ b/tests/Files.t
@@ -50,3 +50,4 @@ my $no_source = Zarn::Helper::Files -> new();
 is($no_source, 0, 'Returns 0 when no source directory is provided');
 
 done_testing();
+1;

--- a/tests/NetworkDataFlowAnalyzer.t
+++ b/tests/NetworkDataFlowAnalyzer.t
@@ -96,3 +96,4 @@ my @alias_entries = $extra_analyzer -> {get_aliases} -> ('ok');
 is_deeply(\@alias_entries, ['alias_ok'], 'Aliases exposed through analyzer');
 
 done_testing();
+1;

--- a/tests/Rules.t
+++ b/tests/Rules.t
@@ -27,3 +27,4 @@ my $no_rules = Zarn::Helper::Rules -> new();
 is($no_rules, 0, 'Returns 0 when no rules file is provided');
 
 done_testing();
+1;

--- a/tests/SourceToSink.t
+++ b/tests/SourceToSink.t
@@ -116,3 +116,4 @@ my @missing_file_results = Zarn::Network::Source_to_Sink -> new([
 is(scalar @missing_file_results, 0, 'No results without file for dataflow');
 
 done_testing();
+1;

--- a/tests/TaintTracker.t
+++ b/tests/TaintTracker.t
@@ -131,3 +131,4 @@ my $missing_tracker = Zarn::Component::Engine::TaintTracker -> new([]);
 is($missing_tracker, 0, 'Missing parameters returns 0');
 
 done_testing();
+1;


### PR DESCRIPTION
### Motivation
- Several Perl test files were failing module-load checks because they did not end with a recognizable true value, causing "Module does not end with '1;'" errors. 
- Ensuring each test file returns a true value fixes loader/runtime errors when the tests are required or loaded.

### Description
- Added a terminating `1;` to the end of the following test files: `tests/CallGraphBuilder.t`, `tests/NetworkDataFlowAnalyzer.t`, `tests/SourceToSink.t`, `tests/AliasAnalyzer.t`, `tests/TaintTracker.t`, `tests/Files.t`, `tests/Rules.t`, `tests/DefUseAnalyzer.t`, and `tests/DataFlow.t`.
- Normalized end-of-file newlines where necessary so files end cleanly after `done_testing()` and the added `1;`.
- No other logic or test behavior was changed; only the module terminators and trailing newlines were added.

### Testing
- No automated tests were executed as part of this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972ca3b1920832b9b7ca248b754cfe5)