### PR TITLE
Fix test package declarations

### DIFF
--- a/tests/AliasAnalyzer.t
+++ b/tests/AliasAnalyzer.t
@@ -1,4 +1,4 @@
-package Tests::AliasAnalyzer;
+package AliasAnalyzer;
 
 use strict;
 use warnings;

--- a/tests/CallGraphBuilder.t
+++ b/tests/CallGraphBuilder.t
@@ -1,4 +1,4 @@
-package Tests::CallGraphBuilder;
+package CallGraphBuilder;
 
 use strict;
 use warnings;

--- a/tests/DataFlow.t
+++ b/tests/DataFlow.t
@@ -1,4 +1,4 @@
-package Tests::DataFlow;
+package DataFlow;
 
 use strict;
 use warnings;

--- a/tests/DefUseAnalyzer.t
+++ b/tests/DefUseAnalyzer.t
@@ -1,4 +1,4 @@
-package Tests::DefUseAnalyzer;
+package DefUseAnalyzer;
 
 use strict;
 use warnings;

--- a/tests/Files.t
+++ b/tests/Files.t
@@ -1,4 +1,4 @@
-package Tests::Files;
+package Files;
 
 use strict;
 use warnings;

--- a/tests/NetworkDataFlowAnalyzer.t
+++ b/tests/NetworkDataFlowAnalyzer.t
@@ -1,4 +1,4 @@
-package Tests::NetworkDataFlowAnalyzer;
+package NetworkDataFlowAnalyzer;
 
 use strict;
 use warnings;

--- a/tests/Rules.t
+++ b/tests/Rules.t
@@ -1,4 +1,4 @@
-package Tests::Rules;
+package Rules;
 
 use strict;
 use warnings;

--- a/tests/SourceToSink.t
+++ b/tests/SourceToSink.t
@@ -1,4 +1,4 @@
-package Tests::SourceToSink;
+package SourceToSink;
 
 use strict;
 use warnings;

--- a/tests/TaintTracker.t
+++ b/tests/TaintTracker.t
@@ -1,4 +1,4 @@
-package Tests::TaintTracker;
+package TaintTracker;
 
 use strict;
 use warnings;


### PR DESCRIPTION
### Motivation
- Several test files declared packages like `package Tests::Name;` that did not match their filenames, which produces Perl package/filename mismatches and can break test loading, so the declarations were aligned with the filenames.

### Description
- Replaced the `package` line at the top of each test under `tests/` so the package name matches the file name (for example `tests/CallGraphBuilder.t` now begins with `package CallGraphBuilder;`).
- Modified files: `tests/AliasAnalyzer.t`, `tests/CallGraphBuilder.t`, `tests/DataFlow.t`, `tests/DefUseAnalyzer.t`, `tests/Files.t`, `tests/NetworkDataFlowAnalyzer.t`, `tests/Rules.t`, `tests/SourceToSink.t`, and `tests/TaintTracker.t`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973e688a588832baedc2c22bc910f0f)