### PR TITLE
Relax List::Util version pin in cpanfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM perl:5.42-slim
 COPY . /usr/src/zarn
 WORKDIR /usr/src/zarn
 
-# --notest skips the test phase of dependencies. This avoids pulling in
-# Clone's test-only dependency B::COW, which fails to build on Perl 5.42.
-RUN cpanm --installdeps --notest .
+RUN cpanm --installdeps .
 
 ENTRYPOINT [ "perl", "./zarn.pl" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM perl:5.42-slim
 COPY . /usr/src/zarn
 WORKDIR /usr/src/zarn
 
-RUN cpanm --installdeps .
+# --notest skips the test phase of dependencies. This avoids pulling in
+# Clone's test-only dependency B::COW, which fails to build on Perl 5.42.
+RUN cpanm --installdeps --notest .
 
 ENTRYPOINT [ "perl", "./zarn.pl" ]

--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,7 @@ requires 'File::Find::Rule', '0.35';
 requires 'Getopt::Long',     '2.58';
 requires 'YAML::Tiny',       '1.76';
 requires 'PPI::Document',    '1.284';
-requires 'List::Util',       '1.70';
+requires 'List::Util',       '1.63';
 
 on 'test' => sub {
       requires 'Test::More',      '1.302219';


### PR DESCRIPTION
Follow-up to #95.

## Problem

The base image (`perl:5.42-slim`) ships `List::Util 1.68_01`, so pinning `1.70` forces an upgrade of a core module during `cpanm --installdeps`:

```
! Installed version (1.68_01) of List::Util is not in range '1.70'
```

The code only uses `List::Util 'any'` (in `lib/Zarn/Network/Source_to_Sink.pm`), which has been available since 1.33. The `1.70` pin is unnecessary.

## Change

- `cpanfile`: `List::Util '1.70'` → `'1.63'`

The `Dockerfile` is intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)