### PR TITLE
Build dependencies with --notest to fix Docker build on Perl 5.42

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM perl:5.42-slim
 COPY . /usr/src/zarn
 WORKDIR /usr/src/zarn
 
-RUN cpanm --installdeps .
+# --notest skips the dependencies' test phase. This avoids building the
+# test-only XS modules B::COW (a test dep of Clone) and Test::LeakTrace
+# (a test dep of Params::Util), which fail to compile on Perl 5.42 and
+# break the PPI install chain. Neither is needed at runtime.
+RUN cpanm --installdeps --notest .
 
 ENTRYPOINT [ "perl", "./zarn.pl" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,6 @@ FROM perl:5.42-slim
 COPY . /usr/src/zarn
 WORKDIR /usr/src/zarn
 
-# --notest skips the dependencies' test phase. This avoids building the
-# test-only XS modules B::COW (a test dep of Clone) and Test::LeakTrace
-# (a test dep of Params::Util), which fail to compile on Perl 5.42 and
-# break the PPI install chain. Neither is needed at runtime.
 RUN cpanm --installdeps --notest .
 
 ENTRYPOINT [ "perl", "./zarn.pl" ]


### PR DESCRIPTION
Fixes the failing Docker image build (the dependency-version PRs #95 and #96 could not fix this — it is not a version issue).

## Problem

On the `perl:5.42-slim` base image, `cpanm --installdeps .` fails because `PPI` pulls in two distributions whose **test suites** depend on XS modules that don't compile on Perl 5.42:

- `Clone` → test dep `B::COW` → fails to build
- `Params::Util` → test dep `Test::LeakTrace` → fails to build

```
! Installing B::COW failed. ... Bailing out the installation for Clone-0.50.
! Installing Test::LeakTrace failed. ... Bailing out the installation for Params-Util-1.102.
! Installing the dependencies failed: Module 'Clone' is not installed, Module 'Params::Util' is not installed
! Bailing out the installation for PPI-1.291.
```

Both `B::COW` and `Test::LeakTrace` are **test-only** dependencies — they are never needed to run `zarn.pl`. There is no `cpanfile`-level fix because they are transitive test dependencies pulled in by `PPI`.

## Change

- `Dockerfile`: `cpanm --installdeps .` → `cpanm --installdeps --notest .`

`--notest` skips the dependencies' test phase, so these test-only XS modules are never built.

## Verification

Simulated the install in a clean local-lib with `cpanm --installdeps --notest .` — completed with **exit 0**; `PPI-1.291`, `Clone-0.50` and `Params-Util-1.102` installed without `B::COW` or `Test::LeakTrace` being fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UER2nztVZXhd7zgn8DcLfb)_