### PR TITLE
Install C toolchain so XS deps build on perl:5.42-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM perl:5.42-slim
 
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY . /usr/src/zarn
 WORKDIR /usr/src/zarn
 


### PR DESCRIPTION
Fixes the failing Docker build while **keeping Perl 5.42**.

## Root cause

The build only ever fails on `Clone` and `Params::Util` — the **only XS (C) modules** in the `PPI` dependency chain — and they fail *instantly*, with no compiler error. The reason is the base image itself:

The official `perl:*-slim` Dockerfile (`FROM debian:bookworm-slim`) installs `gcc` + `make` only to compile perl, then **purges `gcc`** (`apt-get purge --auto-remove`), keeping just `make`. So the final `perl:5.42-slim` image has **no C compiler**. Pure-Perl deps install fine; XS deps can't be built.

This also means simply switching to `perl:5.40-slim` would **not** help — same recipe, `gcc` is purged there too. It is not a Perl-version or module-version problem: `Clone 0.50` and `Params::Util 1.102` compile cleanly on a real Perl 5.42 (verified with both GCC 13 and GCC 14).

## Change

Install a C toolchain before running `cpanm`:

```dockerfile
RUN apt-get update \
 && apt-get install -y --no-install-recommends build-essential \
 && rm -rf /var/lib/apt/lists/*
```

`--notest` is kept so the test-only XS deps (`B::COW`, `Test::LeakTrace`) are not built either.

## Verification

Built Perl 5.42.0 from source locally (with `gcc` available) and ran `cpanm --installdeps --notest .` end-to-end: exit 0, with `Clone`, `Params::Util` and `PPI-1.291` all compiling, installing and loading successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)