### PR TITLE
Update outdated cpanfile dependencies to latest

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'JSON',             '4.10';
+requires 'JSON',             '4.11';
 requires 'File::Find::Rule', '0.35';
 requires 'Getopt::Long',     '2.58';
 requires 'YAML::Tiny',       '1.76';

--- a/cpanfile
+++ b/cpanfile
@@ -2,11 +2,11 @@ requires 'JSON',             '4.11';
 requires 'File::Find::Rule', '0.35';
 requires 'Getopt::Long',     '2.58';
 requires 'YAML::Tiny',       '1.76';
-requires 'PPI::Document',    '1.284';
-requires 'List::Util',       '1.63';
+requires 'PPI::Document',    '1.291';
+requires 'List::Util',       '1.70';
 
 on 'test' => sub {
-      requires 'Test::More',      '1.302219';
+      requires 'Test::More',      '1.302222';
       requires 'Test::Exception', '0.43';
       requires 'File::Temp',      '0.2312';
       requires 'File::Path',      '2.18';


### PR DESCRIPTION
Bumps the outdated `cpanfile` pins to their latest CPAN releases. After this, every declared dependency matches the latest version on CPAN.

| Module | Before | After |
|---|---|---|
| `JSON` | 4.10 | **4.11** |
| `List::Util` | 1.63 | **1.70** |
| `PPI::Document` | 1.284 | **1.291** |
| `Test::More` | 1.302219 | **1.302222** |

The remaining dependencies (`File::Find::Rule`, `Getopt::Long`, `YAML::Tiny`, `Test::Exception`, `File::Temp`, `File::Path`, `File::Spec`, `File::Slurp`) are already at their latest CPAN versions.

Note: the `List::Util` bump back to 1.70 is safe now that the Docker image installs `build-essential` (#98), so the XS `Scalar-List-Utils 1.70` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UER2nztVZXhd7zgn8DcLfb)_